### PR TITLE
Added a required sub-category to doom2-masterlevels.desktop

### DIFF
--- a/runtime/doom2-masterlevels.desktop.in
+++ b/runtime/doom2-masterlevels.desktop.in
@@ -6,5 +6,5 @@ TryExec=/$assets/doom2-masterlevels-tryexec
 Icon=doom2-masterlevels
 Terminal=false
 Type=Application
-Categories=Game;
+Categories=Game;Shooter;
 Keywords=launcher;doomit;


### PR DESCRIPTION
build.opensuse.org will terminate if it isn't set correctly. Yes, it is a bit strict, but we are Germans.

```
[   65s] ERROR: No sufficient Category definition: /home/abuild/rpmbuild/BUILDROOT/game-data-packager-44-0.x86_64//usr/share/applications/doom2-masterlevels.desktop 
```

https://en.opensuse.org/openSUSE:Packaging_desktop_menu_categories#Game